### PR TITLE
Expanded latents generation

### DIFF
--- a/tortoise/get_conditioning_latents.py
+++ b/tortoise/get_conditioning_latents.py
@@ -2,8 +2,6 @@
 import argparse
 import os
 import torch
-from glob import glob
-
 from api import TextToSpeech
 from tortoise.utils.audio import load_audio, get_voices
 

--- a/tortoise/get_conditioning_latents.py
+++ b/tortoise/get_conditioning_latents.py
@@ -1,6 +1,8 @@
+# +
 import argparse
 import os
 import torch
+from glob import glob
 
 from api import TextToSpeech
 from tortoise.utils.audio import load_audio, get_voices
@@ -13,11 +15,15 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--voice', type=str, help='Selects the voice to convert to conditioning latents', default='pat2')
     parser.add_argument('--output_path', type=str, help='Where to store outputs.', default='../results/conditioning_latents')
+    parser.add_argument('--latent_averaging_mode', type=int, help='How to average voice latents, 0 for standard, 1 for per-sample, 2 for per-minichunk', default=0)
+
+
     args = parser.parse_args()
     os.makedirs(args.output_path, exist_ok=True)
 
     tts = TextToSpeech()
     voices = get_voices()
+    print(list(voices.keys()))
     selected_voices = args.voice.split(',')
     for voice in selected_voices:
         cond_paths = voices[voice]
@@ -25,6 +31,6 @@ if __name__ == '__main__':
         for cond_path in cond_paths:
             c = load_audio(cond_path, 22050)
             conds.append(c)
-        conditioning_latents = tts.get_conditioning_latents(conds)
+        conditioning_latents = tts.get_conditioning_latents(conds, latent_averaging_mode=args.latent_averaging_mode)
         torch.save(conditioning_latents, os.path.join(args.output_path, f'{voice}.pth'))
 


### PR DESCRIPTION
Originally latents are generated utilizing only first 4.2(6)s from each voice sample file. This PR retains that option, as well as adding 2 alternatives that utilize almost entire voice files ( chunk_count = sample_duration // 4.2(6)s , effectively discarding last non-full chunk):
1) chunk mel conditioning matrices/vectors get averaged over each voice sample, before being passed to latent generation
2) all chunk mel conditioning matrices/vectors get sent to latent generation

In effect, method 1 gives equal weighting to entire voice samples, method 2 takes into account potentially varied sample durations.

With that in mind, the previously recommended sample length of circa 10 seconds (which is still confusing since only first 4.2s were used) is effectively removed, your samples can be however long you desire and will be used in their entirety ( bearing in mind that longer samples will lead to longer latents generation, however it's still a quick process at the end of the day, and the latents can then be saved to avoid re-generating them at every prompt.